### PR TITLE
Add attachment support

### DIFF
--- a/src/NHSD.BuyingCatalogue.EmailClient/EmailAttachment.cs
+++ b/src/NHSD.BuyingCatalogue.EmailClient/EmailAttachment.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.IO;
+
+namespace NHSD.BuyingCatalogue.EmailClient
+{
+    /// <summary>
+    /// Represents an attachment to an e-mail.
+    /// </summary>
+    public sealed class EmailAttachment
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EmailAttachment"/> class
+        /// with the given file name and content.
+        /// </summary>
+        /// <param name="fileName">The file name of the attachment.</param>
+        /// <param name="content">The content of the attachment.</param>
+        public EmailAttachment(string fileName, Stream content)
+        {
+            FileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
+            if (string.IsNullOrWhiteSpace(fileName))
+                throw new ArgumentException($"{nameof(fileName)} is required.", nameof(fileName));
+
+            Content = content ?? throw new ArgumentNullException(nameof(content));
+        }
+
+        /// <summary>
+        /// Gets the file name of the attachment.
+        /// </summary>
+        public string FileName { get; }
+
+        /// <summary>
+        /// Gets the content of the attachment.
+        /// </summary>
+        public Stream Content { get; }
+    }
+}

--- a/src/NHSD.BuyingCatalogue.EmailClient/EmailMessage.cs
+++ b/src/NHSD.BuyingCatalogue.EmailClient/EmailMessage.cs
@@ -62,6 +62,16 @@ namespace NHSD.BuyingCatalogue.EmailClient
         }
 
         /// <summary>
+        /// Gets or sets the recipient (to address) of the message.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <see langref="null"/>.</exception>
+        public EmailAddress? Recipient
+        {
+            get => _recipient;
+            set => _recipient = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        /// <summary>
         /// Gets or sets the subject of the message.
         /// </summary>
         public string? Subject { get; set; }
@@ -77,13 +87,13 @@ namespace NHSD.BuyingCatalogue.EmailClient
         public string? TextBody { get; set; }
 
         /// <summary>
-        /// Gets or sets the recipient (to address) of the message.
+        /// Gets or sets the message attachment.
         /// </summary>
-        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <see langref="null"/>.</exception>
-        public EmailAddress? Recipient
-        {
-            get => _recipient;
-            set => _recipient = value ?? throw new ArgumentNullException(nameof(value));
-        }
+        public EmailAttachment? Attachment { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the message has an attachment.
+        /// </summary>
+        public bool HasAttachment => Attachment != null;
     }
 }

--- a/src/NHSD.BuyingCatalogue.EmailClient/EmailMessage.cs
+++ b/src/NHSD.BuyingCatalogue.EmailClient/EmailMessage.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace NHSD.BuyingCatalogue.EmailClient
 {
@@ -87,13 +89,13 @@ namespace NHSD.BuyingCatalogue.EmailClient
         public string? TextBody { get; set; }
 
         /// <summary>
-        /// Gets or sets the message attachment.
+        /// Gets the collection of message attachments.
         /// </summary>
-        public EmailAttachment? Attachment { get; set; }
+        public IList<EmailAttachment> Attachments { get; } = new List<EmailAttachment>();
 
         /// <summary>
         /// Gets a value indicating whether the message has an attachment.
         /// </summary>
-        public bool HasAttachment => Attachment != null;
+        public bool HasAttachments => Attachments.Any();
     }
 }

--- a/src/NHSD.BuyingCatalogue.EmailClient/MimeKitExtensions.cs
+++ b/src/NHSD.BuyingCatalogue.EmailClient/MimeKitExtensions.cs
@@ -21,13 +21,17 @@ namespace NHSD.BuyingCatalogue.EmailClient
         /// <param name="emailMessage">The receiving <see cref="EmailMessage"/> instance.</param>
         /// <param name="emailSubjectPrefix">The text used as a prefix to the e-mail subject.</param>
         /// <returns>the corresponding <see cref="MimeMessage"/>.</returns>
-        internal static MimeMessage AsMimeMessage(this EmailMessage emailMessage, string? emailSubjectPrefix)
+        internal static MimeMessage AsMimeMessage(
+            this EmailMessage emailMessage,
+            string? emailSubjectPrefix = null)
         {
             var bodyBuilder = new BodyBuilder
             {
                 HtmlBody = emailMessage.HtmlBody,
                 TextBody = emailMessage.TextBody,
             };
+
+            AddAttachment(bodyBuilder.Attachments, emailMessage);
 
             var message = new MimeMessage
             {
@@ -39,6 +43,15 @@ namespace NHSD.BuyingCatalogue.EmailClient
             message.To.Add(emailMessage.Recipient?.AsMailboxAddress());
 
             return message;
+        }
+
+        private static void AddAttachment(AttachmentCollection attachments, EmailMessage emailMessage)
+        {
+            if (!emailMessage.HasAttachment)
+                return;
+
+            var attachment = emailMessage.Attachment!;
+            attachments.Add(attachment.FileName, attachment.Content);
         }
     }
 }

--- a/src/NHSD.BuyingCatalogue.EmailClient/MimeKitExtensions.cs
+++ b/src/NHSD.BuyingCatalogue.EmailClient/MimeKitExtensions.cs
@@ -47,11 +47,13 @@ namespace NHSD.BuyingCatalogue.EmailClient
 
         private static void AddAttachment(AttachmentCollection attachments, EmailMessage emailMessage)
         {
-            if (!emailMessage.HasAttachment)
+            if (!emailMessage.HasAttachments)
                 return;
 
-            var attachment = emailMessage.Attachment!;
-            attachments.Add(attachment.FileName, attachment.Content);
+            foreach (var attachment in emailMessage.Attachments)
+            {
+                attachments.Add(attachment.FileName, attachment.Content);
+            }
         }
     }
 }

--- a/tests/NHSD.BuyingCatalogue.EmailClient.UnitTests/EmailAddressTests.cs
+++ b/tests/NHSD.BuyingCatalogue.EmailClient.UnitTests/EmailAddressTests.cs
@@ -10,14 +10,22 @@ namespace NHSD.BuyingCatalogue.EmailClient.UnitTests
     internal static class EmailAddressTests
     {
         [Test]
-        public static void Constructor_String_String_InitializesExpectedValues()
+        public static void Constructor_String_String_InitializesDisplayName()
         {
             const string name = "Some Body";
-            const string address = "somebody@notarealaddress.co.uk";
 
-            var emailAddress = new EmailAddress(name, address);
+            var emailAddress = new EmailAddress(name, "a@b.test");
 
             emailAddress.DisplayName.Should().Be(name);
+        }
+
+        [Test]
+        public static void Constructor_String_String_InitializesAddress()
+        {
+            const string address = "somebody@notarealaddress.test";
+
+            var emailAddress = new EmailAddress("Name", address);
+
             emailAddress.Address.Should().Be(address);
         }
 

--- a/tests/NHSD.BuyingCatalogue.EmailClient.UnitTests/EmailAttachmentTests.cs
+++ b/tests/NHSD.BuyingCatalogue.EmailClient.UnitTests/EmailAttachmentTests.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+
+namespace NHSD.BuyingCatalogue.EmailClient.UnitTests
+{
+    [TestFixture]
+    [Parallelizable(ParallelScope.All)]
+    internal static class EmailAttachmentTests
+    {
+        [Test]
+        [SuppressMessage("ReSharper", "ObjectCreationAsStatement", Justification = "Exception testing")]
+        public static void Constructor_NullFileName_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new EmailAttachment(null!, Mock.Of<Stream>()));
+        }
+
+        [TestCase("")]
+        [TestCase("\t")]
+        [SuppressMessage("ReSharper", "ObjectCreationAsStatement", Justification = "Exception testing")]
+        public static void Constructor_WhiteSpaceFileName_ThrowsArgumentException(string fileName)
+        {
+            Assert.Throws<ArgumentException>(() => new EmailAttachment(fileName, Mock.Of<Stream>()));
+        }
+
+        [Test]
+        [SuppressMessage("ReSharper", "ObjectCreationAsStatement", Justification = "Exception testing")]
+        public static void Constructor_NullContent_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new EmailAttachment("fileName", null!));
+        }
+
+        [Test]
+        public static void Constructor_InitializesFileName()
+        {
+            const string fileName = "file.pdf";
+
+            var attachment = new EmailAttachment(fileName, Mock.Of<Stream>());
+
+            attachment.FileName.Should().Be(fileName);
+        }
+
+        [Test]
+        public static void Constructor_InitializesContent()
+        {
+            var content = Mock.Of<Stream>();
+
+            var attachment = new EmailAttachment("fileName", content);
+
+            attachment.Content.Should().Be(content);
+        }
+    }
+}

--- a/tests/NHSD.BuyingCatalogue.EmailClient.UnitTests/EmailMessageTests.cs
+++ b/tests/NHSD.BuyingCatalogue.EmailClient.UnitTests/EmailMessageTests.cs
@@ -155,22 +155,20 @@ namespace NHSD.BuyingCatalogue.EmailClient.UnitTests
         }
 
         [Test]
-        public static void HasAttachment_NullAttachment_ReturnsFalse()
+        public static void HasAttachments_NoAttachments_ReturnsFalse()
         {
             var message = new EmailMessage();
 
-            message.HasAttachment.Should().BeFalse();
+            message.HasAttachments.Should().BeFalse();
         }
 
         [Test]
-        public static void HasAttachment_WithAttachment_ReturnsTrue()
+        public static void HasAttachments_WithAttachment_ReturnsTrue()
         {
-            var message = new EmailMessage
-            {
-                Attachment = new EmailAttachment("fileName", Mock.Of<Stream>()),
-            };
+            var message = new EmailMessage();
+            message.Attachments.Add(new EmailAttachment("fileName", Mock.Of<Stream>()));
 
-            message.HasAttachment.Should().BeTrue();
+            message.HasAttachments.Should().BeTrue();
         }
     }
 }

--- a/tests/NHSD.BuyingCatalogue.EmailClient.UnitTests/MailKitEmailServiceTests.cs
+++ b/tests/NHSD.BuyingCatalogue.EmailClient.UnitTests/MailKitEmailServiceTests.cs
@@ -121,24 +121,19 @@ namespace NHSD.BuyingCatalogue.EmailClient.UnitTests
                     It.IsAny<ITransferProgress>()))
                 .ThrowsAsync(new ServiceNotAuthenticatedException());
 
-            async Task SendEmailAsync()
+            var message = new EmailMessage
             {
-                var message = new EmailMessage
-                {
-                    Sender = new EmailAddress { Address = "from@sender.uk" },
-                    Recipient = new EmailAddress { Address = "to@recipient.uk" },
-                    Subject = "subject",
-                };
+                Sender = new EmailAddress { Address = "from@sender.uk" },
+                Recipient = new EmailAddress { Address = "to@recipient.uk" },
+                Subject = "subject",
+            };
 
-                var service = new MailKitEmailService(
-                    mockTransport.Object,
-                    new SmtpSettings(),
-                    Mock.Of<ILogger<MailKitEmailService>>());
+            var service = new MailKitEmailService(
+                mockTransport.Object,
+                new SmtpSettings(),
+                Mock.Of<ILogger<MailKitEmailService>>());
 
-                await service.SendEmailAsync(message);
-            }
-
-            Assert.ThrowsAsync<ServiceNotAuthenticatedException>(SendEmailAsync);
+            Assert.ThrowsAsync<ServiceNotAuthenticatedException>(async () => await service.SendEmailAsync(message));
 
             mockTransport.Verify(
                 t => t.DisconnectAsync(
@@ -158,24 +153,19 @@ namespace NHSD.BuyingCatalogue.EmailClient.UnitTests
                     It.IsAny<ITransferProgress>()))
                 .ThrowsAsync(new ServiceNotConnectedException());
 
-            async Task SendEmailAsync()
+            var message = new EmailMessage
             {
-                var message = new EmailMessage
-                {
-                    Sender = new EmailAddress { Address = "from@sender.uk" },
-                    Recipient = new EmailAddress { Address = "to@recipient.uk" },
-                    Subject = "subject",
-                };
+                Sender = new EmailAddress { Address = "from@sender.uk" },
+                Recipient = new EmailAddress { Address = "to@recipient.uk" },
+                Subject = "subject",
+            };
 
-                var service = new MailKitEmailService(
-                    mockTransport.Object,
-                    new SmtpSettings(),
-                    Mock.Of<ILogger<MailKitEmailService>>());
+            var service = new MailKitEmailService(
+                mockTransport.Object,
+                new SmtpSettings(),
+                Mock.Of<ILogger<MailKitEmailService>>());
 
-                await service.SendEmailAsync(message);
-            }
-
-            Assert.ThrowsAsync<ServiceNotConnectedException>(SendEmailAsync);
+            Assert.ThrowsAsync<ServiceNotConnectedException>(async () => await service.SendEmailAsync(message));
 
             mockTransport.Verify(
                 t => t.DisconnectAsync(
@@ -187,17 +177,12 @@ namespace NHSD.BuyingCatalogue.EmailClient.UnitTests
         [Test]
         public static void SendEmailAsync_NullEmailMessage_ThrowsException()
         {
-            static async Task SendEmail()
-            {
-                var emailService = new MailKitEmailService(
-                    Mock.Of<IMailTransport>(),
-                    new SmtpSettings(),
-                    Mock.Of<ILogger<MailKitEmailService>>());
+            var emailService = new MailKitEmailService(
+                Mock.Of<IMailTransport>(),
+                new SmtpSettings(),
+                Mock.Of<ILogger<MailKitEmailService>>());
 
-                await emailService.SendEmailAsync(null!);
-            }
-
-            Assert.ThrowsAsync<ArgumentNullException>(SendEmail);
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await emailService.SendEmailAsync(null!));
         }
 
         [Test]
@@ -356,24 +341,19 @@ namespace NHSD.BuyingCatalogue.EmailClient.UnitTests
                     It.IsAny<ITransferProgress>()))
                 .ThrowsAsync(new SmtpFailedRecipientException(SmtpStatusCode.ServiceNotAvailable, "to@recipient.uk"));
 
-            async Task SendEmailAsync()
+            var message = new EmailMessage
             {
-                var message = new EmailMessage
-                {
-                    Sender = new EmailAddress { Address = "from@sender.uk" },
-                    Recipient = new EmailAddress { Address = "to@recipient.uk" },
-                    Subject = "subject",
-                };
+                Sender = new EmailAddress { Address = "from@sender.uk" },
+                Recipient = new EmailAddress { Address = "to@recipient.uk" },
+                Subject = "subject",
+            };
 
-                var service = new MailKitEmailService(
-                    mockTransport.Object,
-                    new SmtpSettings(),
-                    mockLogger.Object);
+            var service = new MailKitEmailService(
+                mockTransport.Object,
+                new SmtpSettings(),
+                mockLogger.Object);
 
-                await service.SendEmailAsync(message);
-            }
-
-            Assert.ThrowsAsync<SmtpFailedRecipientException>(SendEmailAsync);
+            Assert.ThrowsAsync<SmtpFailedRecipientException>(async () => await service.SendEmailAsync(message));
             mockLogger.Verify(
                 x => x.Log(
                     LogLevel.Error,

--- a/tests/NHSD.BuyingCatalogue.EmailClient.UnitTests/MimeKitExtensionsTests.cs
+++ b/tests/NHSD.BuyingCatalogue.EmailClient.UnitTests/MimeKitExtensionsTests.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
 using FluentAssertions;
 using MimeKit;
 using NUnit.Framework;
@@ -11,90 +13,37 @@ namespace NHSD.BuyingCatalogue.EmailClient.UnitTests
     internal static class MimeKitExtensionsTests
     {
         [Test]
-        public static void AsMailboxAddress_ReturnsExpectedValue()
+        public static void AsMailboxAddress_ReturnsExpectedType()
         {
             const string name = "Some Body";
-            const string address = "somebody@notarealaddress.co.uk";
 
-            var emailAddress = new EmailAddress(name, address);
+            var emailAddress = new EmailAddress(name, "a@b.test");
             var mailboxAddress = emailAddress.AsMailboxAddress();
 
             mailboxAddress.Should().BeOfType<MailboxAddress>();
-            mailboxAddress.Name.Should().Be(name);
-            mailboxAddress.Address.Should().Be(address);
-        }
-
-        [TestCase(null)]
-        [TestCase("")]
-        [TestCase(" ")]
-        public static void AsMimeMessage_ReturnsExpectedValues_WithNoSubjectPrefix(string emailSubjectPrefix)
-        {
-            const string recipient = "recipient@somedomain.uk";
-            const string sender = "sender@somedomain.nhs.uk";
-            const string subject = "Subject";
-            const string htmlBody = "HTML";
-            const string textBody = "Text";
-
-            var emailMessage = new EmailMessage
-            {
-                Sender = new EmailAddress { Address = sender },
-                Recipient = new EmailAddress { Address = recipient },
-                Subject = subject,
-                HtmlBody = "HTML",
-                TextBody = "Text",
-            };
-
-            var mimeMessage = emailMessage.AsMimeMessage(emailSubjectPrefix);
-
-            mimeMessage.Should().BeOfType<MimeMessage>();
-
-            IEnumerable<InternetAddress> from = mimeMessage.From;
-            from.Should().HaveCount(1);
-            from.First().As<MailboxAddress>().Address.Should().Be(sender);
-
-            IEnumerable<InternetAddress> to = mimeMessage.To;
-            to.Should().HaveCount(1);
-            to.First().As<MailboxAddress>().Address.Should().Be(recipient);
-
-            mimeMessage.Subject.Should().Be(subject);
-            mimeMessage.HtmlBody.Should().Be(htmlBody);
-            mimeMessage.TextBody.Should().Be(textBody);
         }
 
         [Test]
-        public static void AsMimeMessage_ReturnsExpectedValuesWithPrefix()
+        public static void AsMailboxAddress_InitializesName()
         {
-            const string recipient = "recipient@somedomain.uk";
-            const string sender = "sender@somedomain.nhs.uk";
-            const string subject = "Subject";
-            const string htmlBody = "HTML";
-            const string textBody = "Text";
-            const string emailSubjectPrefix = "Prefix";
+            const string name = "Some Body";
 
-            var emailMessage = new EmailMessage
-            {
-                Sender = new EmailAddress { Address = sender },
-                Recipient = new EmailAddress { Address = recipient },
-                Subject = subject,
-                HtmlBody = "HTML",
-                TextBody = "Text",
-            };
+            var emailAddress = new EmailAddress(name, "a@b.test");
+            var mailboxAddress = emailAddress.AsMailboxAddress();
 
-            var mimeMessage = emailMessage.AsMimeMessage(emailSubjectPrefix);
+            mailboxAddress.Name.Should().Be(name);
+        }
 
-            mimeMessage.Should().BeOfType<MimeMessage>();
+        [Test]
+        public static void AsMailboxAddress_InitializesAddress()
+        {
+            const string address = "somebody@notarealaddress.test";
 
-            IEnumerable<InternetAddress> from = mimeMessage.From;
-            from.Should().HaveCount(1);
-            from.First().As<MailboxAddress>().Address.Should().Be(sender);
+            var emailAddress = new EmailAddress("Name", address);
+            var mailboxAddress = emailAddress.AsMailboxAddress();
 
-            IEnumerable<InternetAddress> to = mimeMessage.To;
-            to.Should().HaveCount(1);
-            to.First().As<MailboxAddress>().Address.Should().Be(recipient);
-
-            mimeMessage.Subject.Should().Be($"{emailSubjectPrefix} {subject}");
-            mimeMessage.HtmlBody.Should().Be(htmlBody);
-            mimeMessage.TextBody.Should().Be(textBody);
+            mailboxAddress.Should().BeOfType<MailboxAddress>();
+            mailboxAddress.Address.Should().Be(address);
         }
 
         [Test]
@@ -108,8 +57,172 @@ namespace NHSD.BuyingCatalogue.EmailClient.UnitTests
 
             var mimeMessage = emailMessage.AsMimeMessage(string.Empty);
 
-            mimeMessage.Should().BeOfType<MimeMessage>();
             mimeMessage.Subject.Should().Be(string.Empty);
+        }
+
+        [Test]
+        public static void AsMimeMessage_ReturnsExpectedType()
+        {
+            var emailMessage = new EmailMessage
+            {
+                Sender = new EmailAddress { Address = "sender@somedomain.nhs.test" },
+                Recipient = new EmailAddress { Address = "recipient@somedomain.nhs.test" },
+            };
+
+            var mimeMessage = emailMessage.AsMimeMessage();
+
+            mimeMessage.Should().BeOfType<MimeMessage>();
+        }
+
+        [Test]
+        public static void AsMimeMessage_InitializesSender()
+        {
+            const string sender = "sender@somedomain.test";
+
+            var emailMessage = new EmailMessage
+            {
+                Sender = new EmailAddress { Address = sender },
+                Recipient = new EmailAddress { Address = "recipient@somedomain.test" },
+            };
+
+            var mimeMessage = emailMessage.AsMimeMessage();
+
+            IEnumerable<InternetAddress> from = mimeMessage.From;
+            from.Should().HaveCount(1);
+            from.First().As<MailboxAddress>().Address.Should().Be(sender);
+        }
+
+        [Test]
+        public static void AsMimeMessage_InitializesRecipient()
+        {
+            const string recipient = "recipient@somedomain.test";
+
+            var emailMessage = new EmailMessage
+            {
+                Sender = new EmailAddress { Address = "sender@somedomain.test" },
+                Recipient = new EmailAddress { Address = recipient },
+            };
+
+            var mimeMessage = emailMessage.AsMimeMessage();
+
+            IEnumerable<InternetAddress> to = mimeMessage.To;
+            to.Should().HaveCount(1);
+            to.First().As<MailboxAddress>().Address.Should().Be(recipient);
+        }
+
+        [Test]
+        public static void AsMimeMessage_InitializesSubject()
+        {
+            const string subject = "Subject";
+
+            var emailMessage = new EmailMessage
+            {
+                Sender = new EmailAddress { Address = "sender@somedomain.nhs.test" },
+                Recipient = new EmailAddress { Address = "recipient@somedomain.nhs.test" },
+                Subject = subject,
+            };
+
+            var mimeMessage = emailMessage.AsMimeMessage();
+
+            mimeMessage.Subject.Should().Be(subject);
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("\t")]
+        public static void AsMimeMessage_NullOrWhiteSpaceSubjectPrefix_InitializesSubject(string emailSubjectPrefix)
+        {
+            const string subject = "Subject";
+
+            var emailMessage = new EmailMessage
+            {
+                Sender = new EmailAddress { Address = "sender@somedomain.nhs.test" },
+                Recipient = new EmailAddress { Address = "recipient@somedomain.nhs.test" },
+                Subject = subject,
+            };
+
+            var mimeMessage = emailMessage.AsMimeMessage(emailSubjectPrefix);
+
+            mimeMessage.Subject.Should().Be(subject);
+        }
+
+        [Test]
+        public static void AsMimeMessage_WithSubjectPrefix_InitializesSubject()
+        {
+            const string emailSubjectPrefix = "Prefix";
+            const string subject = "Subject";
+
+            var emailMessage = new EmailMessage
+            {
+                Sender = new EmailAddress { Address = "sender@somedomain.nhs.test" },
+                Recipient = new EmailAddress { Address = "recipient@somedomain.nhs.test" },
+                Subject = subject,
+            };
+
+            var mimeMessage = emailMessage.AsMimeMessage(emailSubjectPrefix);
+
+            mimeMessage.Subject.Should().Be($"{emailSubjectPrefix} {subject}");
+        }
+
+        [Test]
+        public static void AsMimeMessage_InitializesHtmlBody()
+        {
+            const string htmlBody = "HTML";
+
+            var emailMessage = new EmailMessage
+            {
+                Sender = new EmailAddress { Address = "sender@somedomain.nhs.test" },
+                Recipient = new EmailAddress { Address = "recipient@somedomain.nhs.test" },
+                HtmlBody = htmlBody,
+            };
+
+            var mimeMessage = emailMessage.AsMimeMessage();
+
+            mimeMessage.HtmlBody.Should().Be(htmlBody);
+        }
+
+        [Test]
+        public static void AsMimeMessage_InitializesTextBody()
+        {
+            const string textBody = "Text";
+
+            var emailMessage = new EmailMessage
+            {
+                Sender = new EmailAddress { Address = "sender@somedomain.nhs.test" },
+                Recipient = new EmailAddress { Address = "recipient@somedomain.nhs.test" },
+                TextBody = textBody,
+            };
+
+            var mimeMessage = emailMessage.AsMimeMessage();
+
+            mimeMessage.TextBody.Should().Be(textBody);
+        }
+
+        [Test]
+        public static void AsMimeMessage_WithAttachment_HasExpectedAttachment()
+        {
+            const string fileName = "test.csv";
+            const string content = "Hello World";
+            using var contentStream = new MemoryStream(Encoding.ASCII.GetBytes(content));
+
+            var emailMessage = new EmailMessage
+            {
+                Sender = new EmailAddress { Address = "sender@somedomain.nhs.test" },
+                Recipient = new EmailAddress { Address = "recipient@somedomain.test" },
+                Attachment = new EmailAttachment(fileName, contentStream),
+            };
+
+            var mimeMessage = emailMessage.AsMimeMessage();
+            var attachments = mimeMessage.Attachments.ToList();
+
+            attachments.Should().HaveCount(1);
+
+            var attachment = (TextPart)attachments.First();
+
+            attachment.Should().NotBeNull();
+            attachment.ContentType.MimeType.Should().Be("text/csv");
+            attachment.FileName.Should().Be(fileName);
+            attachment.Text.Should().Be(content);
         }
     }
 }

--- a/tests/NHSD.BuyingCatalogue.EmailClient.UnitTests/MimeKitExtensionsTests.cs
+++ b/tests/NHSD.BuyingCatalogue.EmailClient.UnitTests/MimeKitExtensionsTests.cs
@@ -209,8 +209,9 @@ namespace NHSD.BuyingCatalogue.EmailClient.UnitTests
             {
                 Sender = new EmailAddress { Address = "sender@somedomain.nhs.test" },
                 Recipient = new EmailAddress { Address = "recipient@somedomain.test" },
-                Attachment = new EmailAttachment(fileName, contentStream),
             };
+
+            emailMessage.Attachments.Add(new EmailAttachment(fileName, contentStream));
 
             var mimeMessage = emailMessage.AsMimeMessage();
             var attachments = mimeMessage.Attachments.ToList();

--- a/tests/NHSD.BuyingCatalogue.EmailClient.UnitTests/SmtpSettingsTests.cs
+++ b/tests/NHSD.BuyingCatalogue.EmailClient.UnitTests/SmtpSettingsTests.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 namespace NHSD.BuyingCatalogue.EmailClient.UnitTests
 {
     [TestFixture]
+    [Parallelizable(ParallelScope.All)]
     internal static class SmtpSettingsTests
     {
         [Test]


### PR DESCRIPTION
Added support for adding a single attachment. Also made tests more granular and marked all as parallelizable.

Story: AB#3928
Task: AB#9358